### PR TITLE
fixed invalid link

### DIFF
--- a/_data/course.yml
+++ b/_data/course.yml
@@ -15,7 +15,7 @@ gradescope_201a: "https://www.gradescope.com/"
 perusall_link: "https://app.perusall.com/courses/ecs-201a-001-wq-2023/"
 
 154b_github_classroom_link: "https://github.com/ECS154B-WQ23"
-dino_cpu_link: "https://github.com/ECS154B-WQ23"
+dino_cpu_link: "https://github.com/jlpteaching/dinocpu"
 154b_assignment1_github_link: "https://github.com/ECS154B-WQ23/dinocpu-assignment1"
 154b_assignment2_github_link: "https://github.com/ECS154B-WQ23/dinocpu-assignment2"
 154b_assignment3_github_link: "https://github.com/ECS154B-WQ23/dinocpu-assignment3"

--- a/_data/course.yml
+++ b/_data/course.yml
@@ -15,6 +15,7 @@ gradescope_201a: "https://www.gradescope.com/"
 perusall_link: "https://app.perusall.com/courses/ecs-201a-001-wq-2023/"
 
 154b_github_classroom_link: "https://github.com/ECS154B-WQ23"
+dino_cpu_link: "https://github.com/ECS154B-WQ23"
 154b_assignment1_github_link: "https://github.com/ECS154B-WQ23/dinocpu-assignment1"
 154b_assignment2_github_link: "https://github.com/ECS154B-WQ23/dinocpu-assignment2"
 154b_assignment3_github_link: "https://github.com/ECS154B-WQ23/dinocpu-assignment3"


### PR DESCRIPTION
Currently the DINOCPU documentation links on https://jlpteaching.github.io/comparch/modules/dino%20cpu/index/ are leading to a 404 page. 